### PR TITLE
feat: AI coach UX improvements — calendar, colors, weekly chart, cleanup

### DIFF
--- a/src/strava/app.py
+++ b/src/strava/app.py
@@ -116,7 +116,7 @@ def show_welcome_page():
                 "🔗 Connect with Strava",
                 auth_url,
                 type="primary",
-                use_container_width=True,
+                width="stretch",
             )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             st.error(f"Failed to generate authorization URL: {exc}")

--- a/src/strava/constants.py
+++ b/src/strava/constants.py
@@ -33,13 +33,14 @@ ZONE_LABELS: Dict[str, str] = {
 # Used in training_plan.py for the monthly calendar cells.
 
 WORKOUT_COLORS: Dict[str, str] = {
-    "easy_run": "#B8E0B8",  # Pastel green        – aerobic easy
-    "recovery": "#A8D8EA",  # Pastel blue         – recovery
-    "tempo": "#FECBA0",  # Pastel peach-amber  – tempo / threshold
-    "intervals": "#F5C6C6",  # Pastel pink-red     – intervals / hard effort
-    "long_run": "#B8D4F0",  # Pastel mid-blue     – long run
-    "rest": "#D0D0D0",  # Light grey          – rest
-    "cross_training": "#D4B8E8",  # Pastel purple       – cross training
+    "easy_run": "#66BB6A",  # Medium green        – aerobic easy
+    "recovery": "#42A5F5",  # Medium blue         – recovery
+    "tempo": "#FFA726",  # Amber-orange        – tempo / threshold
+    "intervals": "#EF5350",  # Vivid red           – intervals / hard effort
+    "long_run": "#26C6DA",  # Cyan                – long run (distinct from easy)
+    "rest": "#78909C",  # Blue-grey           – rest
+    "cross_training": "#AB47BC",  # Purple              – cross training
+    "strength": "#9E9E9E",  # Medium grey         – strength / weights
 }
 
 STATUS_COLORS: Dict[str, str] = {
@@ -62,6 +63,7 @@ WORKOUT_TYPE_COMPATIBLE: Dict[str, set] = {
     "long_run": {"long_run", "Run"},  # Must be long distance
     "rest": {"rest"},  # Rest is always rest
     "cross_training": {"cross_training", "Ride", "Swim", "Walk", "Hike", "Yoga"},
+    "strength": {"strength", "WeightTraining", "Workout", "CrossFit"},
 }
 
 # Minimum distance ratio: actual distance / planned distance must exceed this
@@ -144,6 +146,10 @@ BEST_EFFORT_NAMES = [
 
 # Set variant used for O(1) membership checks during import
 BEST_EFFORT_NAMES_SET = frozenset(BEST_EFFORT_NAMES)
+
+# ── Null-like string values to treat as missing ────────────────────────
+# Used when parsing LLM output or DB fields that may contain placeholder text.
+INVALID_STR_VALUES = frozenset(("n/a", "none", "null", ""))
 
 
 def classify_zone(hr: float, zones: tuple) -> str:

--- a/src/strava/utils/ai_coach.py
+++ b/src/strava/utils/ai_coach.py
@@ -495,9 +495,11 @@ class AICoach:
             duration = (
                 _fmt_duration(row["moving_time"]) if pd.notnull(row.get("moving_time")) else "N/A"
             )
-            hr = _fmt_hr(row.get("average_heart_rate")) if pd.notnull(
-                row.get("average_heart_rate")
-            ) else ""
+            hr = (
+                _fmt_hr(row.get("average_heart_rate"))
+                if pd.notnull(row.get("average_heart_rate"))
+                else ""
+            )
             is_indoor = " [INDOOR]" if row.get("trainer") else ""
             elev = (
                 f"| Elev: {row['elevation_gain']}m" if pd.notnull(row.get("elevation_gain")) else ""

--- a/src/strava/utils/ai_coach.py
+++ b/src/strava/utils/ai_coach.py
@@ -14,6 +14,7 @@ from google import genai
 from google.genai import types
 from dotenv import load_dotenv
 
+from strava.constants import INVALID_STR_VALUES
 from strava.db.db_manager import DatabaseManager
 
 
@@ -49,6 +50,20 @@ def _fmt_duration(total_seconds: float) -> str:
     if h:
         return f"{h}:{m:02d}:{s:02d}"
     return f"{m}:{s:02d}"
+
+
+def _fmt_dist_km(dist_m) -> str:
+    """Format a distance in metres as km string, or 'N/A'."""
+    if dist_m is None or not pd.notnull(dist_m):
+        return "N/A"
+    return f"{float(dist_m) / 1000:.2f}km"
+
+
+def _fmt_hr(hr) -> str:
+    """Format a heart-rate value as 'NNNbpm', or 'N/A'."""
+    if hr is None or not pd.notnull(hr):
+        return "N/A"
+    return f"{int(hr)}bpm"
 
 
 # ── Tool function declarations for google-genai ───────────────────────
@@ -470,7 +485,7 @@ class AICoach:
         for _, row in recent.iterrows():
             date_str = row["activity_date"].strftime("%Y-%m-%d")
             dist_m = row.get("distance")
-            dist = f"{dist_m / 1000:.2f}km" if pd.notnull(dist_m) else "N/A"
+            dist = _fmt_dist_km(dist_m)
 
             pace = (
                 _pace_from_time_dist(row["moving_time"], dist_m)
@@ -480,11 +495,9 @@ class AICoach:
             duration = (
                 _fmt_duration(row["moving_time"]) if pd.notnull(row.get("moving_time")) else "N/A"
             )
-            hr = (
-                f"{int(row['average_heart_rate'])}bpm"
-                if pd.notnull(row.get("average_heart_rate"))
-                else ""
-            )
+            hr = _fmt_hr(row.get("average_heart_rate")) if pd.notnull(
+                row.get("average_heart_rate")
+            ) else ""
             is_indoor = " [INDOOR]" if row.get("trainer") else ""
             elev = (
                 f"| Elev: {row['elevation_gain']}m" if pd.notnull(row.get("elevation_gain")) else ""
@@ -559,16 +572,12 @@ class AICoach:
         return "\n".join(
             [
                 f"Details for Activity {activity_id} ({row.get('activity_name', 'Run')}):",
-                f"  Distance: {dist_m / 1000:.2f}km" if pd.notnull(dist_m) else "  Distance: N/A",
+                f"  Distance: {_fmt_dist_km(dist_m)}",
                 f"  Duration (moving): {duration}",
                 f"  Overall Pace: {overall_pace}",
                 f"  Indoor: {'Yes' if row.get('trainer') else 'No'}",
                 f"  Elevation Gain: {elev}",
-                (
-                    f"  Avg HR: {int(row['average_heart_rate'])}bpm"
-                    if pd.notnull(row.get("average_heart_rate"))
-                    else "  Avg HR: N/A"
-                ),
+                f"  Avg HR: {_fmt_hr(row.get('average_heart_rate'))}",
                 f"  Intensity (Time in Zones): {hr_analysis}",
                 f"  Aerobic Decoupling (Cardiac Drift): {decoupling}",
                 (
@@ -661,7 +670,7 @@ class AICoach:
 
         lines = [
             f"Km-by-km splits for Activity {activity_id} " f"({row.get('activity_name', 'Run')}):",
-            f"  Total: {dist_m / 1000:.2f}km | Moving time: {duration} "
+            f"  Total: {_fmt_dist_km(dist_m)} | Moving time: {duration} "
             f"| Overall pace: {overall_pace}",
             "",
         ]
@@ -729,11 +738,13 @@ class AICoach:
         for _, row in races.head(10).iterrows():
             date_str = row["activity_date"].strftime("%Y-%m-%d")
             dist_m = row.get("distance")
-            dist = f"{dist_m / 1000:.2f}km" if pd.notnull(dist_m) else "N/A"
             time_str = (
                 _fmt_duration(row["elapsed_time"]) if pd.notnull(row.get("elapsed_time")) else "N/A"
             )
-            lines.append(f"- {date_str}: {row.get('activity_name', 'Race')} | {dist} | {time_str}")
+            lines.append(
+                f"- {date_str}: {row.get('activity_name', 'Race')} "
+                f"| {_fmt_dist_km(dist_m)} | {time_str}"
+            )
         return "\n".join(lines)
 
     def _tool_get_race_performances(self, limit: int = 5) -> str:
@@ -758,7 +769,6 @@ class AICoach:
             name = row.get("activity_name", "Race")
 
             dist_m = row.get("distance")
-            dist = f"{dist_m / 1000:.2f}km" if pd.notnull(dist_m) else "N/A"
             time_str = (
                 _fmt_duration(row["moving_time"]) if pd.notnull(row.get("moving_time")) else "N/A"
             )
@@ -768,11 +778,7 @@ class AICoach:
                 if pd.notnull(row.get("moving_time")) and pd.notnull(dist_m) and dist_m > 0
                 else "N/A"
             )
-            hr = (
-                f"{int(row['average_heart_rate'])}bpm"
-                if pd.notnull(row.get("average_heart_rate"))
-                else "N/A"
-            )
+            hr = _fmt_hr(row.get("average_heart_rate"))
 
             score_col = (
                 "suffer_score"
@@ -789,7 +795,7 @@ class AICoach:
             )
 
             lines.append(
-                f"- {date_str} '{name}' | Dist: {dist} | Time: {time_str} | "
+                f"- {date_str} '{name}' | Dist: {_fmt_dist_km(dist_m)} | Time: {time_str} | "
                 f"Pace: {pace} | HR: {hr} | Elev: {elev} | Load: {score}"
             )
         return "\n".join(lines)
@@ -976,7 +982,7 @@ class AICoach:
             cad = f" | Cad: {lap['average_cadence']:.0f}spm" if lap.get("average_cadence") else ""
             lines.append(
                 f"  Lap {lap['lap_index'] + 1}: "
-                f"{dist_m / 1000:.2f}km | {duration} | {pace}{hr}{cad}"
+                f"{_fmt_dist_km(dist_m)} | {duration} | {pace}{hr}{cad}"
             )
         return "\n".join(lines)
 
@@ -1404,7 +1410,7 @@ If a day has multiple sessions, output SEPARATE workout objects with the same "d
         """Convert parsed plan JSON to a list of workout dicts for DB insertion."""
 
         def _parse_num(val):
-            if val is None or str(val).lower() in ("n/a", "none", "null", ""):
+            if val is None or str(val).lower() in INVALID_STR_VALUES:
                 return None
             try:
                 return float(val)
@@ -1415,7 +1421,7 @@ If a day has multiple sessions, output SEPARATE workout objects with the same "d
         for week in plan_json.get("weeks", []):
             for w in week.get("workouts", []):
                 hr_zone = w.get("hr_zone", "")
-                if str(hr_zone).lower() in ("n/a", "none", "null"):
+                if str(hr_zone).lower() in INVALID_STR_VALUES:
                     hr_zone = None
                 workouts.append(
                     {

--- a/src/strava/views/_training_plan_calendar.py
+++ b/src/strava/views/_training_plan_calendar.py
@@ -5,9 +5,10 @@ import datetime
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
+import plotly.graph_objects as go
 import streamlit as st
 
-from strava.constants import ACTIVITY_TYPE_COLORS, WORKOUT_COLORS
+from strava.constants import ACTIVITY_TYPE_COLORS, INVALID_STR_VALUES, WORKOUT_COLORS
 from strava.db.db_manager import DatabaseManager
 from strava.utils.ai_coach import AICoach
 
@@ -68,8 +69,6 @@ _ICON_MAP: Dict[str, str] = {
     "rest": "\U0001f634",
 }
 
-_INVALID_STR_VALUES = frozenset(("n/a", "none", "null", ""))
-
 
 def _get_workout_color(workout_type: str) -> str:
     return WORKOUT_COLORS.get(workout_type, ACTIVITY_TYPE_COLORS.get(workout_type, "#CFCFCF"))
@@ -95,10 +94,10 @@ def _build_workout_html(w: Dict[str, Any]) -> str:
 
     stats_parts = []
     dist = w.get("target_distance_km")
-    if dist and str(dist).lower() not in _INVALID_STR_VALUES:
+    if dist and str(dist).lower() not in INVALID_STR_VALUES:
         stats_parts.append(f"{dist}km")
     pace_val = w.get("target_pace_min_km")
-    if pace_val and str(pace_val).lower() not in _INVALID_STR_VALUES:
+    if pace_val and str(pace_val).lower() not in INVALID_STR_VALUES:
         try:
             pv = float(pace_val)
             mins, secs = int(pv), int((pv - int(pv)) * 60)
@@ -116,7 +115,7 @@ def _build_workout_html(w: Dict[str, Any]) -> str:
     if w.get("description") and w["workout_type"] != "rest":
         details.append(w["description"])
     hr_zone = w.get("target_hr_zone")
-    if hr_zone and str(hr_zone).lower() not in _INVALID_STR_VALUES:
+    if hr_zone and str(hr_zone).lower() not in INVALID_STR_VALUES:
         details.append(hr_zone)
     if details:
         html += f'<div class="cal-detail">{sep.join(details)}</div>'
@@ -138,7 +137,7 @@ def _build_activity_html(act) -> str:
     hr_val = act.get("average_heart_rate")
     hr = f"{int(hr_val)}bpm" if pd.notnull(hr_val) and hr_val else ""
     stats = " \u00b7 ".join(d for d in [dist_str, pace, hr] if d)
-    label = stats if stats else name
+    label = f"{name}" + (f" \u00b7 {stats}" if stats else "")
     return f'<div class="cal-actual" title="{name}">{emoji} {label}</div>'
 
 
@@ -214,24 +213,104 @@ def _render_calendar(year: int, month: int, workouts: list, activities_df: pd.Da
     st.markdown(html, unsafe_allow_html=True)
 
 
-def _render_weekly_breakdown(workouts: list) -> None:
-    """Render weekly training breakdown below the calendar."""
+def _render_weekly_breakdown(workouts: list, activities_df: pd.DataFrame) -> None:
+    """Render weekly training breakdown as a planned vs done bar chart."""
     st.markdown("### \U0001f4ca Weekly Breakdown")
     if not workouts:
         return
+
     wdf = pd.DataFrame(workouts)
     wdf["workout_date"] = pd.to_datetime(wdf["workout_date"])
-    wdf["week"] = wdf["workout_date"].dt.isocalendar().week
-    for week_num, group in wdf.groupby("week"):
-        total_dist = group["target_distance_km"].sum() if "target_distance_km" in wdf.columns else 0
-        n_workouts = len(group[group["workout_type"] != "rest"])
-        completed = group["completed"].sum() if "completed" in wdf.columns else 0
-        dist_str = (
-            f"{total_dist:.1f}km planned, " if pd.notnull(total_dist) and total_dist > 0 else ""
+    # ISO week start (Monday)
+    wdf["week_start"] = wdf["workout_date"] - pd.to_timedelta(
+        wdf["workout_date"].dt.dayofweek, unit="D"
+    )
+    wdf["target_distance_km"] = pd.to_numeric(wdf["target_distance_km"], errors="coerce").fillna(0)
+
+    # Build activity_id → actual distance (km) lookup from the Strava activities
+    act_dist: Dict[int, float] = {}
+    if not activities_df.empty and "activity_id" in activities_df.columns:
+        for _, row in activities_df.iterrows():
+            raw = row.get("distance", 0)
+            if pd.notnull(raw) and raw > 0:
+                act_dist[int(row["activity_id"])] = float(raw) / 1000.0
+
+    today = datetime.date.today()
+    rows = []
+    for week_start, grp in wdf.groupby("week_start"):
+        non_rest = grp[grp["workout_type"] != "rest"]
+        planned_km = non_rest["target_distance_km"].sum()
+        n_planned = len(non_rest)
+        n_done = int(grp["completed"].sum()) if "completed" in grp.columns else 0
+
+        # Actual km: use matched activity distance where available, else planned km of completed
+        done_km = 0.0
+        for _, w in grp.iterrows():
+            if not w.get("completed"):
+                continue
+            act_id = w.get("activity_id")
+            if act_id and int(act_id) in act_dist:
+                done_km += act_dist[int(act_id)]
+            elif w["target_distance_km"] > 0:
+                done_km += float(w["target_distance_km"])
+
+        week_date = week_start.date() if hasattr(week_start, "date") else week_start
+        is_past = week_date + datetime.timedelta(days=6) < today
+        rows.append(
+            {
+                "week_start": week_date,
+                "label": week_date.strftime("W%W\n%b %d"),
+                "planned_km": round(planned_km, 1),
+                "done_km": round(done_km, 1),
+                "n_planned": n_planned,
+                "n_done": n_done,
+                "is_past": is_past,
+            }
         )
-        st.markdown(
-            f"**Week {week_num}**: {n_workouts} workouts, " f"{dist_str}{int(completed)} completed"
+
+    if not rows:
+        return
+
+    rows.sort(key=lambda r: r["week_start"])
+    labels = [r["label"] for r in rows]
+    planned = [r["planned_km"] for r in rows]
+    done = [r["done_km"] for r in rows]
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Bar(
+            name="Planned",
+            x=labels,
+            y=planned,
+            marker_color="#B8D4F0",
+            text=[f"{v:.1f}km" if v else "" for v in planned],
+            textposition="outside",
+            textfont={"size": 11},
         )
+    )
+    fig.add_trace(
+        go.Bar(
+            name="Done",
+            x=labels,
+            y=done,
+            marker_color="#66BB6A",
+            text=[f"{v:.1f}km" if v else "" for v in done],
+            textposition="outside",
+            textfont={"size": 11},
+        )
+    )
+    fig.update_layout(
+        barmode="group",
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+        font={"color": "#ddd", "size": 12},
+        legend={"orientation": "h", "y": 1.1, "x": 0},
+        margin={"t": 40, "b": 20, "l": 10, "r": 10},
+        yaxis={"title": "km", "gridcolor": "rgba(255,255,255,0.08)"},
+        xaxis={"tickfont": {"size": 11}},
+        height=320,
+    )
+    st.plotly_chart(fig)
 
 
 _EDITABLE_WORKOUT_TYPES: List[str] = [
@@ -242,6 +321,7 @@ _EDITABLE_WORKOUT_TYPES: List[str] = [
     "rest",
     "cross_training",
     "recovery",
+    "strength",
 ]
 
 
@@ -262,7 +342,7 @@ def _render_edit_table(database: DatabaseManager, workouts: List[Dict[str, Any]]
 
     rows = [
         {
-            "Date": w["workout_date"],
+            "Date": datetime.date.fromisoformat(w["workout_date"]),
             "Type": w.get("workout_type", "rest"),
             "Description": w.get("description") or "",
             "Distance (km)": w.get("target_distance_km"),
@@ -297,7 +377,7 @@ def _render_edit_table(database: DatabaseManager, workouts: List[Dict[str, Any]]
             "HR Zone": st.column_config.TextColumn("HR Zone", max_chars=20),
         },
         hide_index=True,
-        use_container_width=True,
+        width="stretch",
         num_rows="fixed",
         key="edit_workouts_table",
     )
@@ -411,4 +491,4 @@ def _tab_calendar(database: DatabaseManager, dataframe: pd.DataFrame) -> None:
             f'<span style="color:{color};font-size:12px">{label}</span>',
             unsafe_allow_html=True,
         )
-    _render_weekly_breakdown(plan["workouts"])
+    _render_weekly_breakdown(plan["workouts"], dataframe)

--- a/src/strava/views/_training_plan_generate.py
+++ b/src/strava/views/_training_plan_generate.py
@@ -13,6 +13,15 @@ from strava.utils.ai_coach import AICoach
 from strava.views._training_plan_calendar import _render_month_nav, _render_calendar
 
 
+def _set_draft_plan_state(plan_text: str, chat, goal: str) -> None:
+    """Persist a freshly generated or adapted plan into Streamlit session state."""
+    st.session_state["draft_plan_text"] = plan_text
+    st.session_state["draft_plan_json"] = AICoach.parse_plan_json(plan_text)
+    st.session_state["gemini_chat"] = chat
+    st.session_state["user_goal"] = goal
+    st.session_state["chat_history"] = [{"role": "assistant", "content": plan_text}]
+
+
 def _get_coach(database: DatabaseManager) -> AICoach:
     """Return a cached AICoach, recreating it only when HR zones change.
 
@@ -77,11 +86,7 @@ def _show_adapt_input(database: DatabaseManager, active_plan: dict) -> None:
                 chat, plan_text = coach.adapt_plan(adapt_request)
 
             if chat and plan_text:
-                st.session_state["draft_plan_text"] = plan_text
-                st.session_state["draft_plan_json"] = AICoach.parse_plan_json(plan_text)
-                st.session_state["gemini_chat"] = chat
-                st.session_state["user_goal"] = active_plan["goal"]
-                st.session_state["chat_history"] = [{"role": "assistant", "content": plan_text}]
+                _set_draft_plan_state(plan_text, chat, active_plan["goal"])
                 st.session_state["is_adapting"] = False
                 st.session_state["adapting_plan_id"] = active_plan["plan_id"]
                 st.session_state["nav_target"] = "\U0001f4dd Create / Adapt Plan"
@@ -114,11 +119,7 @@ def _show_goal_input(database: DatabaseManager) -> None:
             chat, plan_text = coach.generate_plan(user_goal)
 
         if chat and plan_text:
-            st.session_state["draft_plan_text"] = plan_text
-            st.session_state["draft_plan_json"] = AICoach.parse_plan_json(plan_text)
-            st.session_state["gemini_chat"] = chat
-            st.session_state["user_goal"] = user_goal
-            st.session_state["chat_history"] = [{"role": "assistant", "content": plan_text}]
+            _set_draft_plan_state(plan_text, chat, user_goal)
             st.rerun()
         else:
             st.error(plan_text)
@@ -153,6 +154,7 @@ def _handle_accept(database: DatabaseManager) -> None:
     st.session_state["gemini_chat"] = None
     st.session_state["chat_history"] = []
     st.session_state["plan_accepted"] = False
+    st.session_state.pop("coach_snapshot", None)
     st.success("\u2705 Plan saved! Check the **Calendar** tab.")
     st.session_state["nav_target"] = "\U0001f4c5 Calendar"
     st.rerun()

--- a/src/strava/views/training_plan.py
+++ b/src/strava/views/training_plan.py
@@ -9,6 +9,7 @@ import streamlit as st
 
 from strava.constants import COMPLETION_MIN_DISTANCE_RATIO, WORKOUT_TYPE_COMPATIBLE
 from strava.db.db_manager import DatabaseManager
+from strava.utils.ai_coach import AICoach
 from strava.views._training_plan_calendar import _tab_calendar
 from strava.views._training_plan_generate import _get_coach, _tab_generate_plan
 
@@ -183,6 +184,32 @@ def _render_activity_selector(dataframe: pd.DataFrame) -> None:
             )
 
 
+def _apply_feedback_plan(database: DatabaseManager, plan_json: dict) -> None:
+    """Archive the current active plan and save a coach-revised plan from the feedback chat."""
+    active = database.get_active_plan()
+    if active:
+        database.archive_plan(active["plan_id"])
+
+    goal = active["goal"] if active else st.session_state.get("user_goal", "Coach-revised plan")
+    plan_text = st.session_state.pop("_pending_feedback_plan_text", "")
+    plan_id = database.insert_training_plan(
+        {
+            "goal": goal,
+            "start_date": plan_json.get("start_date", datetime.date.today().isoformat()),
+            "end_date": plan_json.get("end_date"),
+            "status": "active",
+            "raw_llm_response": plan_text,
+        }
+    )
+    workout_records = AICoach.plan_json_to_workouts(plan_id, plan_json)
+    database.insert_planned_workouts(workout_records)
+
+    st.session_state.pop("_pending_feedback_plan_json", None)
+    st.session_state.pop("coach_snapshot", None)
+    st.success("\u2705 Plan updated! Check the **Calendar** tab.")
+    st.rerun()
+
+
 def _render_coaching_chat(database: DatabaseManager) -> None:
     """Render the coaching chat interface."""
     st.markdown("### \U0001f4ac Ask Your Coach")
@@ -226,7 +253,29 @@ def _render_coaching_chat(database: DatabaseManager) -> None:
                     st.session_state["feedback_history"].append(
                         {"role": "assistant", "content": reply}
                     )
+                    new_plan_json = AICoach.parse_plan_json(reply)
+                    if new_plan_json:
+                        st.session_state["_pending_feedback_plan_json"] = new_plan_json
+                        st.session_state["_pending_feedback_plan_text"] = reply
                     st.rerun()
+
+    pending_json = st.session_state.get("_pending_feedback_plan_json")
+    if pending_json:
+        st.info(
+            "\U0001f4cb The coach included an updated plan in their response. "
+            "Apply it to replace your current plan?"
+        )
+        col1, col2 = st.columns(2)
+        with col1:
+            if st.button(
+                "\u2705 Apply Plan Changes", type="primary", key="apply_feedback_plan_btn"
+            ):
+                _apply_feedback_plan(database, pending_json)
+        with col2:
+            if st.button("Dismiss", key="dismiss_feedback_plan_btn"):
+                st.session_state.pop("_pending_feedback_plan_json", None)
+                st.session_state.pop("_pending_feedback_plan_text", None)
+                st.rerun()
 
 
 def _tab_feedback(database: DatabaseManager, dataframe: pd.DataFrame) -> None:


### PR DESCRIPTION
## Summary

- **Calendar DateColumn fix** — `workout_date` strings converted to `datetime.date` before passing to `st.data_editor`, eliminating the `ColumnDataKind.STRING` incompatibility error
- **Plan changes from feedback chat** — when the coach returns a full plan JSON in the Feedback & Chat tab, a banner appears offering "Apply Plan Changes"; accepting it archives the old plan and saves the new one to the DB so the calendar updates
- **Stale coach snapshot** — cleared from session state after plan accept/apply so the brief auto-regenerates on next load
- **Weekly Breakdown chart** — replaced the plain text list with a grouped Planned vs Done bar chart (per week, uses actual Strava activity distances where linked)
- **Activity names on calendar** — cells now show activity name + stats (distance · pace · HR) instead of stats only
- **Vivid calendar colors** — replaced pastel `WORKOUT_COLORS` with Material Design 400-level palette; each workout type is now visually distinct
- **`strength` workout type** — added color (`#9E9E9E`), edit-table dropdown entry, and Strava activity matching (`WeightTraining`, `Workout`, `CrossFit`)
- **Deprecated Streamlit API** — `use_container_width` → `width='stretch'` for `st.link_button` / `st.data_editor`; removed spurious kwarg from `st.plotly_chart`

## Refactoring

- Moved `INVALID_STR_VALUES` frozenset to `constants.py`; both `ai_coach.py` and `_training_plan_calendar.py` now import it
- Extracted `_set_draft_plan_state()` in `_training_plan_generate.py` — deduplicated 3 identical 5-line session-state blocks
- Added `_fmt_dist_km()` and `_fmt_hr()` helpers in `ai_coach.py` — replaced 6+ repeated inline formatting patterns

## Test plan

- [ ] All 60 existing tests pass (`pytest -q`)
- [ ] `flake8` and `pylint` both report 10.00/10 with no warnings
- [ ] Calendar tab: edit upcoming workouts (date picker works, no DateColumn error)
- [ ] Feedback chat: ask coach to revise plan → "Apply Plan Changes" banner appears → accept → calendar reflects changes
- [ ] Weekly Breakdown shows bar chart with Planned / Done bars grouped by week
- [ ] Calendar cells show activity name alongside stats
- [ ] Workout colors (tempo = amber, intervals = red, easy = green, etc.) visible and distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)